### PR TITLE
Introduce and use CProverString.isValidInt/Long

### DIFF
--- a/src/main/java/java/lang/Integer.java
+++ b/src/main/java/java/lang/Integer.java
@@ -410,6 +410,10 @@ public final class Integer extends Number implements Comparable<Integer> {
                                             " greater than Character.MAX_RADIX");
         }
 
+        if(!CProverString.isValidInt(s, radix)) {
+            throw new NumberFormatException(s + " isn't a valid integer");
+        }
+
         return CProverString.parseInt(s, radix);
     }
 
@@ -431,11 +435,7 @@ public final class Integer extends Number implements Comparable<Integer> {
      *               parsable integer.
      */
     public static int parseInt(String s) throws NumberFormatException {
-        if (s == null) {
-            throw new NumberFormatException("null");
-        }
-
-        return CProverString.parseInt(s, 10);
+        return parseInt(s, 10);
     }
 
     /**

--- a/src/main/java/java/lang/Long.java
+++ b/src/main/java/java/lang/Long.java
@@ -473,6 +473,9 @@ public final class Long extends Number implements Comparable<Long> {
             throw new NumberFormatException("radix " + radix +
                                             " greater than Character.MAX_RADIX");
         }
+        if (!CProverString.isValidLong(s, radix)) {
+            throw new NumberFormatException(s + " isn't a valid long");
+        }
 
         return CProverString.parseLong(s, radix);
     }
@@ -502,10 +505,7 @@ public final class Long extends Number implements Comparable<Long> {
      *             parsable {@code long}.
      */
     public static long parseLong(String s) throws NumberFormatException {
-        if (s == null) {
-            throw new NumberFormatException("null");
-        }
-        return CProverString.parseLong(s, 10);
+        return parseLong(s, 10);
     }
 
     /**

--- a/src/main/java/org/cprover/CProverString.java
+++ b/src/main/java/org/cprover/CProverString.java
@@ -442,18 +442,38 @@ public final class CProverString
     }
 
     /**
-     * Exactly as Integer.parseInt, except s is already checked non-null and the
-     * radix is already checked in-range.
+     * Exactly as Integer.parseInt, except s is already checked non-null, the
+     * radix is already checked in-range and 's' is known to be a valid integer
+     * according to isValidInt below
      */
     public static int parseInt(String s, int radix) {
         return CProver.nondetInt();
     }
 
     /**
-     * Exactly as Long.parseLong, except s is already checked non-null and the
-     * radix is already checked in-range.
+     * Exactly as Long.parseLong, except s is already checked non-null, the
+     * radix is already checked in-range and 's' is known to be a valid integer
+     * according to isValidLong below
      */
     public static long parseLong(String s, int radix) {
         return CProver.nondetLong();
+    }
+
+    /**
+     * Returns true if string 's' is a valid integer: contains at least one
+     * digit, perhaps a leading '+' or '-', and doesn't contain invalid chars
+     * for the given radix.
+     */
+    public static boolean isValidInt(String s, int radix) {
+        return CProver.nondetBoolean();
+    }
+
+    /**
+     * Returns true if string 's' is a valid long: contains at least one
+     * digit, perhaps a leading '+' or '-', and doesn't contain invalid chars
+     * for the given radix.
+     */
+    public static boolean isValidLong(String s, int radix) {
+        return CProver.nondetBoolean();
     }
 }


### PR DESCRIPTION
These determine whether a string would pass parseInt/parseLong without throwing due to
containing inappropriate characters. The previous versions were broken because that check
was a mandatory part of Integer.parseInt and cousins, causing side-effects on the input
string.