### PR TITLE
Update version of checkout action from 2 to 3

### DIFF
--- a/.github/workflows/models_library_pr.yml
+++ b/.github/workflows/models_library_pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Java environment
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '16'
           distribution: 'adopt'

--- a/.github/workflows/models_library_pr.yml
+++ b/.github/workflows/models_library_pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Java environment
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
This avoids a warning about a deprecated node.js version (version 12).

This is the java-models-library equivalent to this cbmc PR - https://github.com/diffblue/cbmc/pull/7245